### PR TITLE
Update crm.html

### DIFF
--- a/crm.html
+++ b/crm.html
@@ -49,8 +49,7 @@
 </head>
 <body>
   <div class="dashboard-container">
-    <a id="additional-order-link" class="additional-order-btn" href="#">Additional Order</a>
-    <a id="help-slip" class="additional-order-btn" href="#">Help Slip</a>    
+    <a id="additional-order-link" class="additional-order-btn" href="#">Additional Order</a>   
     <a id="purchase-request-link" class="additional-order-btn" href="#">View Purchase Req.</a>    
     <a class="additional-order-btn" href="https://shorturl.at/kuC1i" target="_blank">Checklist</a>
     <button id="raise-purchase-request-btn" class="additional-order-btn">Raise Purchase Request</button>


### PR DESCRIPTION
Help slip Remove

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard header navigation: removed the Help Slip link. Additional Order remains accessible as the only item in that pair. Other header links (View Purchase Req., Checklist, Raise Purchase Request) are unchanged. Visual-only adjustment; no behavioral changes. This streamlines the header and reduces clutter for users, without affecting workflows or scripts. No other pages or features are impacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->