### PR TITLE
Update generateTiles.js

### DIFF
--- a/js/generateTiles.js
+++ b/js/generateTiles.js
@@ -8,8 +8,7 @@ document.getElementById("purchase-request-link").href =
   "https://ntwoods.github.io/ordertodispatch/purchaseRequestStatus.html?crmName=" + ENCODED_CRM;
 document.getElementById("completed-sales-orders-btn").href =
   "https://ntwoods.github.io/ordertodispatch/completedSalesOrdersCRM.html?crm=" + ENCODED_CRM;
-document.getElementById("help-slip").href =
-  "https://ntwoods.github.io/ordertodispatch/raiseTicket";
+
 
 
 


### PR DESCRIPTION
Help slip Button Remove


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Removed the hyperlink from the Help (Slip) control; it no longer navigates to an external page when clicked.
  - Users will notice the Help control no longer functions as a link, with no visual layout changes.
  - All other links and buttons, including Purchase Request and Completed Sales Orders, continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->